### PR TITLE
Make stats_collector betterC compat

### DIFF
--- a/source/stdx/allocator/building_blocks/stats_collector.d
+++ b/source/stdx/allocator/building_blocks/stats_collector.d
@@ -160,7 +160,7 @@ struct StatsCollector(Allocator, ulong flags = Options.all,
 private:
     import stdx.allocator.internal : Ternary;
 
-    static string define(string type, string[] names...)
+    enum define = (string type, string[] names...)
     {
         string result;
         foreach (v; names)
@@ -169,7 +169,7 @@ private:
                 ~ "public const("~type~") "~v~"() const { return _"~v~"; }"
                 ~ "}";
         return result;
-    }
+    };
 
     void add(string counter)(sizediff_t n)
     {


### PR DESCRIPTION
I used the enum lambda trick to assure the compiler that the code is only used at compile time, otherwise the function would go through code generation and complain about not having a GC for appending (even though we only call it from CTFE). By using the enum, code generation won't happen, ergo the error doesn't get triggered.